### PR TITLE
Hotfixing to remove the 'uuid()' default from the checklist's 'id' fi…

### DIFF
--- a/app/Database/Migrations/2025-07-24-202255_Checklisttable.php
+++ b/app/Database/Migrations/2025-07-24-202255_Checklisttable.php
@@ -14,7 +14,7 @@ class Checklisttable extends Migration
                 'type' => 'VARCHAR',
                 'constraint' => 36,
                 'null' => false,
-                'default' => new RawSql('uuid()'),
+                //'default' => new RawSql('uuid()'),
             ],
             'created' => [
                 'type' => 'TIMESTAMP',


### PR DESCRIPTION
…eld - migration is currently failing.